### PR TITLE
Link footer version to repository

### DIFF
--- a/openrsvp/api.py
+++ b/openrsvp/api.py
@@ -28,13 +28,14 @@ from .database import SessionLocal
 from .models import Channel, Event, RSVP
 from .scheduler import start_scheduler, stop_scheduler
 from .storage import fetch_root_token, init_db
-from .utils import humanize_time, duration_between
+from .utils import duration_between, get_repo_url, humanize_time
 
 logger = logging.getLogger(__name__)
 
 app = FastAPI(title="OpenRSVP", version="0.1")
 templates = Jinja2Templates(directory=str(Path(__file__).parent / "templates"))
 templates.env.globals["app_version"] = app.version
+templates.env.globals["repo_url"] = get_repo_url()
 templates.env.filters["relative_time"] = humanize_time
 templates.env.filters["duration"] = duration_between
 

--- a/openrsvp/templates/base.html
+++ b/openrsvp/templates/base.html
@@ -37,7 +37,15 @@
     <footer class="bg-dark text-white py-3 mt-auto">
       <div class="container d-flex flex-wrap justify-content-between align-items-center gap-2 small">
         <span>OpenRSVP</span>
-        <span>Version {{ app_version }}</span>
+        <span>
+          {% if repo_url %}
+          <a class="link-light text-decoration-none" href="{{ repo_url }}" target="_blank" rel="noopener">
+            Version {{ app_version }}
+          </a>
+          {% else %}
+          Version {{ app_version }}
+          {% endif %}
+        </span>
       </div>
     </footer>
     <script src="https://unpkg.com/htmx.org@1.9.12"></script>


### PR DESCRIPTION
## Summary
- add helper to derive the repository URL from the local Git configuration and share it with templates
- update the base layout to turn the footer version text into a link to the repository when available

## Testing
- python -m compileall openrsvp

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d36eb52b883318e7b7a9718e98cbf)