### PR TITLE
Sort homepage channel dropdown by score

### DIFF
--- a/openrsvp/crud.py
+++ b/openrsvp/crud.py
@@ -26,7 +26,11 @@ def get_channel_by_slug(session: Session, slug: str) -> Channel | None:
 
 
 def get_public_channels(session: Session) -> list[Channel]:
-    stmt = select(Channel).where(Channel.visibility == "public").order_by(Channel.name.asc())
+    stmt = (
+        select(Channel)
+        .where(Channel.visibility == "public")
+        .order_by(Channel.score.desc(), Channel.name.asc())
+    )
     return session.scalars(stmt).all()
 
 


### PR DESCRIPTION
## Summary
- order public channels by score (then name) when building the channel list
- ensures the homepage dropdown shows higher-scored channels first

## Testing
- python -m compileall openrsvp

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d382803fc83318d6b6aaf07b9fd8a)