### PR TITLE
Render event descriptions as sanitized markdown

### DIFF
--- a/openrsvp/api.py
+++ b/openrsvp/api.py
@@ -29,7 +29,7 @@ from .database import SessionLocal
 from .models import Channel, Event, RSVP
 from .scheduler import start_scheduler, stop_scheduler
 from .storage import fetch_root_token, init_db
-from .utils import duration_between, get_repo_url, humanize_time
+from .utils import duration_between, get_repo_url, humanize_time, render_markdown
 
 logger = logging.getLogger(__name__)
 
@@ -39,6 +39,7 @@ templates.env.globals["app_version"] = app.version
 templates.env.globals["repo_url"] = get_repo_url()
 templates.env.filters["relative_time"] = humanize_time
 templates.env.filters["duration"] = duration_between
+templates.env.filters["markdown"] = render_markdown
 
 ADMIN_EVENTS_PER_PAGE = 25
 EVENTS_PER_PAGE = 10

--- a/openrsvp/templates/event.html
+++ b/openrsvp/templates/event.html
@@ -27,7 +27,11 @@
       <a href="/channel/{{ event.channel.slug }}" class="fw-semibold text-decoration-none">{{ event.channel.name }}</a>
     </div>
     {% endif %}
-    <p>{{ event.description or 'No description provided.' }}</p>
+    {% if event.description %}
+    <div class="mb-4 markdown-content">{{ event.description | markdown | safe }}</div>
+    {% else %}
+    <p class="text-muted">No description provided.</p>
+    {% endif %}
     <div class="mb-4">
       <a class="btn btn-success" href="/e/{{ event.id }}/rsvp">Submit RSVP</a>
     </div>

--- a/openrsvp/templates/event_admin.html
+++ b/openrsvp/templates/event_admin.html
@@ -15,6 +15,7 @@
           <div class="mb-3">
             <label class="form-label">Description</label>
             <textarea name="description" class="form-control" rows="3">{{ event.description or '' }}</textarea>
+            <div class="form-text">Supports basic Markdown.</div>
           </div>
           <div class="mb-3">
             <label class="form-label">Start Time</label>

--- a/openrsvp/templates/event_create.html
+++ b/openrsvp/templates/event_create.html
@@ -16,6 +16,7 @@
           <div class="mb-3">
             <label class="form-label">Description</label>
             <textarea name="description" class="form-control" rows="3"></textarea>
+            <div class="form-text">Supports basic Markdown for richer details.</div>
           </div>
           <div class="mb-3">
             <label class="form-label">Start Time</label>

--- a/openrsvp/templates/home.html
+++ b/openrsvp/templates/home.html
@@ -40,7 +40,7 @@
           {% endif %}
         </div>
       </div>
-      <p class="mb-0 mt-2 text-muted">{{ event.description or 'No description provided.' }}</p>
+      <div class="mb-0 mt-2 text-muted small markdown-content">{{ (event.description or 'No description provided.') | markdown | safe }}</div>
     </a>
   {% endfor %}
   </div>


### PR DESCRIPTION
## Summary
- add a Markdown rendering helper that sanitizes user input before templating
- render event descriptions as Markdown on the event detail and home pages
- mention Markdown support in event creation and admin forms

## Testing
- python -m compileall openrsvp


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e227f3e8483318bd6ad0442415a82)