### PR TITLE
Cache public channels lookup in event submission

### DIFF
--- a/openrsvp/api.py
+++ b/openrsvp/api.py
@@ -356,6 +356,7 @@ def submit_event(
     timezone_offset_minutes: int = Form(0),
     db: Session = Depends(get_db),
 ):
+    public_channels = get_public_channels(db)
     channel = None
     cleaned_channel_name = channel_name.strip() if channel_name else ""
     if cleaned_channel_name:
@@ -368,7 +369,7 @@ def submit_event(
                 "event_create.html",
                 {
                     "request": request,
-                    "public_channels": get_public_channels(db),
+                    "public_channels": public_channels,
                     "message": _channel_error_message(str(exc)),
                     "message_class": "alert-danger",
                 },
@@ -385,7 +386,7 @@ def submit_event(
                 "event_create.html",
                 {
                     "request": request,
-                    "public_channels": get_public_channels(db),
+                    "public_channels": public_channels,
                     "message": "End time must be after the start time.",
                     "message_class": "alert-danger",
                 },
@@ -407,6 +408,7 @@ def submit_event(
             "request": request,
             "event": event,
             "admin_link": f"/e/{event.id}/admin/{event.admin_token}",
+            "public_channels": public_channels,
         },
     )
 


### PR DESCRIPTION
## Summary
- fetch the public channel list once when submitting an event and reuse it for template responses
- reuse the cached list for channel validation errors and event creation responses instead of re-querying

## Testing
- ⚠️ `python - <<'PY' ...` (fails: fastapi dependency missing and pip install blocked by proxy)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e3b4504d88331a920e9687fb90bde)