### PR TITLE
Fix duplicate admin update alerts

### DIFF
--- a/openrsvp/templates/base.html
+++ b/openrsvp/templates/base.html
@@ -30,7 +30,10 @@
     </nav>
     <main class="container mb-5 flex-grow-1">
       {% if message %}
-      <div class="alert {{ message_class or 'alert-info' }}">{{ message }}</div>
+      <div class="alert {{ message_class or 'alert-info' }} alert-dismissible fade show" role="alert">
+        {{ message }}
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+      </div>
       {% endif %}
       {% block content %}{% endblock %}
     </main>

--- a/openrsvp/templates/event_admin.html
+++ b/openrsvp/templates/event_admin.html
@@ -1,7 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
 <h2>Event Admin: {{ event.title }} {% if event.is_private %}<span class="badge bg-warning text-dark">Private</span>{% endif %}</h2>
-{% if message %}<div class="alert {{ message_class or 'alert-success' }}">{{ message }}</div>{% endif %}
 <div class="row">
   <div class="col-lg-7 mb-4">
     <div class="card">

--- a/openrsvp/templates/rsvp_edit.html
+++ b/openrsvp/templates/rsvp_edit.html
@@ -1,7 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
 <h2>Manage RSVP for {{ event.title }}</h2>
-{% if message %}<div class="alert {{ message_class or 'alert-success' }}">{{ message }}</div>{% endif %}
 <form method="post" action="/e/{{ event.id }}/rsvp/{{ rsvp.rsvp_token }}" class="mt-3">
   <div class="mb-3">
     <label class="form-label">Name</label>


### PR DESCRIPTION
## Summary
- make the shared message alert dismissible using Bootstrap’s close button
- remove per-page message blocks on event admin and RSVP edit pages to avoid duplicate alerts

## Testing
- python -m compileall openrsvp

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e404abca88331a331a2f46ce77558)